### PR TITLE
Add default location for general & slow query logs

### DIFF
--- a/templates/default/logrotate_script.erb
+++ b/templates/default/logrotate_script.erb
@@ -1,7 +1,7 @@
 # - I put everything in one block and added sharedscripts, so that mysql gets
 #   flush-logs'd only once.
 #   Else the binary logs would automatically increase by n times every day.
-/var/log/mysql-<%= @mysql_instance %>/mysql.log /var/log/mysql-<%= @mysql_instance %>/mysql-slow.log /var/log/mysql-<%= @mysql_instance %>/error.log {
+/var/log/mysql-<%= @mysql_instance %>/mysql.log /var/log/mysql-<%= @mysql_instance %>/mysql-slow.log /var/log/mysql-<%= @mysql_instance %>/error.log /var/lib/mysql-<%= @mysql_instance %>/*.log {
   daily
   rotate 7
   missingok


### PR DESCRIPTION
As it turns out, the default location for the slow query log file using the `mysql` >= 8.0 cookbook is `/var/lib/mysql-#{name}`

This adds a catchall for any `*.log` files at that path, to avoid someone using this cookbook & thinking they’re all set, then nearly being bitten by a disk filling up (like me).